### PR TITLE
Fix warn_unused_result compilation error

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -286,7 +286,13 @@ static void ibus_unikey_engine_property_activate(IBusEngine* engine,
 
     if (strcmp(prop_name, "more-settings") == 0)
     {
-        system(LIBEXECDIR "/ibus-setup-unikey &");
+        int ret = 0;
+
+        ret = system(LIBEXECDIR "/ibus-setup-unikey &");
+        if (ret == -1)
+        {
+	    g_print("Failed to open ibus-setup-unikey");
+        }
         return;
     }
 


### PR DESCRIPTION
Fix warn_unused_result compilation error from engine.cpp's system() call.
This error appears when you compile with [-Werror=unused-result] flag.